### PR TITLE
make Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+PREFIX ?= /usr/local/bin
+
+mermaid-ascii: cmd/*.go
+	go build
+
+.PHONY: install
+install: $(PREFIX)/mermaid-ascii
+
+$(PREFIX)/mermaid-ascii: mermaid-ascii | $(PREFIX)
+	install -m 755 $< $@
+
+.PHONY: clean
+clean:
+	$(RM) mermaid-ascii
+
+.PHONY: uninstall
+uninstall:
+	$(RM) $(PREFIX)/mermaid-ascii


### PR DESCRIPTION
One bog-standard Makefile, for standard Unix-like installations.

Usage:

`make`

`sudo make install`
