### PR TITLE
Completions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,27 @@
 PREFIX ?= /usr/local/bin
 pkgname ?= mermaid-ascii
 
+targets += $(PREFIX)/$(pkgname)
+
+ifneq (,$(wildcard /usr/share/bash-completion/completions/))
+  targets += /usr/share/bash-completion/completions/$(pkgname)
+endif
+
+all: build/$(pkgname) build/completions/bash build/completions/zsh build/completions/fish
+
 build/$(pkgname): cmd/*.go | build/
 	go build -o $@
 
 .PHONY: install
-install: $(PREFIX)/$(pkgname)
+install: $(targets)
 
 $(PREFIX)/$(pkgname): build/$(pkgname) | $(PREFIX)
 	install -m 755 $< $@
+/usr/share/bash-completion/completions/$(pkgname): build/completions/bash
+	install -m 755 $< $@
+
+build/completions/%: build/$(pkgname) | build/completions/
+	./$< completion $(@F) > $@
 
 %/:
 	mkdir -p $@
@@ -19,7 +32,7 @@ clean:
 
 .PHONY: uninstall
 uninstall:
-	$(RM) $(PREFIX)/$(pkgname)
+	$(RM) $(targets)
 
 dev:
 	air


### PR DESCRIPTION
The `Makefile` generates the completion script.  If `/usr/share/bash-completions/completions/` exists, then the bash completion installs there.