### PR TITLE
fix: do not print diagram to console twice

### DIFF
--- a/cmd/draw.go
+++ b/cmd/draw.go
@@ -164,7 +164,6 @@ func drawMap(properties *graphProperties) string {
 		d = d.debugCoordWrapper(g)
 	}
 	s := drawingToString(d)
-	fmt.Println(s)
 	return s
 }
 


### PR DESCRIPTION
This change prevents the CLI from printing the ascii diagram twice to the console, and closes #43.