### PR TITLE
feat(graph): tolerant graph/flowchart type detection

### DIFF
--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -38,9 +38,9 @@ type graphNodeSpec struct {
 }
 
 type textEdge struct {
-	parent         textNode
-	child          textNode
-	label          string
+	parent          textNode
+	child           textNode
+	label           string
 	isBidirectional bool
 }
 
@@ -371,14 +371,33 @@ func mermaidFileToMap(mermaid, styleType string) (*graphProperties, error) {
 		return &properties, errors.New("missing graph definition")
 	}
 
-	// First line should either say "graph TD" or "graph LR"
-	switch lines[0] {
-	case "graph LR", "flowchart LR":
-		properties.graphDirection = "LR"
-	case "graph TD", "flowchart TD", "graph TB", "flowchart TB":
-		properties.graphDirection = "TD"
-	default:
-		return &properties, fmt.Errorf("unsupported graph type '%s'. Supported types: graph TD, graph TB, graph LR, flowchart TD, flowchart TB, flowchart LR", lines[0])
+	// The first line declares the diagram: "graph" or "flowchart" followed by an
+	// optional direction (e.g. "flowchart LR", "graph TD", or a bare "graph").
+	// strings.Fields collapses any surrounding or repeated whitespace, so
+	// indented or trailing-padded declarations parse correctly; TrimRight drops a
+	// trailing separator (mermaid allows "graph TD;").
+	fields := strings.Fields(strings.TrimRight(lines[0], "; \t\r"))
+	if len(fields) == 0 || (fields[0] != "graph" && fields[0] != "flowchart") {
+		return &properties, fmt.Errorf("unsupported graph type '%s'. Supported types: 'graph' or 'flowchart' with an optional direction (TD, TB, BT, LR, RL)", strings.TrimSpace(lines[0]))
+	}
+	if len(fields) > 2 {
+		return &properties, fmt.Errorf("unexpected tokens after graph direction: %q", strings.Join(fields[2:], " "))
+	}
+
+	// Mermaid defaults to top-down when no direction is given. The renderer only
+	// lays out along the horizontal (LR) or vertical (TD) axis; the reverse
+	// directions RL and BT are accepted but drawn on their axis without the
+	// reversal (RL renders left-to-right, BT top-down).
+	properties.graphDirection = "TD"
+	if len(fields) == 2 {
+		switch fields[1] {
+		case "LR", "RL":
+			properties.graphDirection = "LR"
+		case "TD", "TB", "BT":
+			properties.graphDirection = "TD"
+		default:
+			return &properties, fmt.Errorf("unsupported graph direction '%s'. Supported directions: TD, TB, BT, LR, RL", fields[1])
+		}
 	}
 	lines = lines[1:]
 

--- a/cmd/parse_test.go
+++ b/cmd/parse_test.go
@@ -174,3 +174,54 @@ func TestMermaidFileToMapUsesLatestExplicitLabel(t *testing.T) {
 		t.Fatal("expected A label to remain explicit")
 	}
 }
+
+// TestGraphTypeDetection verifies that the diagram declaration line is parsed
+// tolerantly: surrounding whitespace, a missing direction (defaults to
+// top-down), and the reverse directions RL/BT are all accepted.
+func TestGraphTypeDetection(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantDir string
+		wantErr bool
+	}{
+		{"plain graph TD", "graph TD\nA --> B", "TD", false},
+		{"flowchart LR", "flowchart LR\nA --> B", "LR", false},
+		{"leading whitespace", "    flowchart LR\n    A --> B", "LR", false},
+		{"trailing whitespace", "graph LR    \nA --> B", "LR", false},
+		{"indented graph TD", "        graph TD\n        A --> B", "TD", false},
+		{"bare graph defaults to TD", "graph\nA --> B", "TD", false},
+		{"bare flowchart defaults to TD", "flowchart\nA --> B", "TD", false},
+		{"TB maps to TD", "flowchart TB\nA --> B", "TD", false},
+		{"RL maps to LR axis", "graph RL\nA --> B", "LR", false},
+		{"BT maps to TD axis", "flowchart BT\nA --> B", "TD", false},
+		{"trailing semicolon bare", "graph;\nA --> B", "TD", false},
+		{"trailing semicolon with direction", "graph TD;\nA --> B", "TD", false},
+		{"flowchart LR semicolon", "flowchart LR;\nA --> B", "LR", false},
+		{"CRLF line ending", "graph TD\r\nA --> B", "TD", false},
+		{"tab separator", "graph\tLR\nA --> B", "LR", false},
+		{"lowercase direction errors", "graph td\nA --> B", "", true},
+		{"extra tokens error", "graph TD foo\nA --> B", "", true},
+		{"unknown type errors", "sequenceDiagram\nA->>B: x", "", true},
+		{"unknown direction errors", "graph SIDEWAYS\nA --> B", "", true},
+		{"empty input errors", "", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			props, err := mermaidFileToMap(tt.input, "cli")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got direction %q", props.graphDirection)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if props.graphDirection != tt.wantDir {
+				t.Errorf("direction = %q, want %q", props.graphDirection, tt.wantDir)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The diagram-type detector matched the first line with an exact string `switch` (`"graph LR"`, `"flowchart TD"`, …). Any of the following produced `unsupported graph type`:

- **leading/trailing whitespace** — e.g. a ` ```mermaid ` block indented under a list item (`    flowchart LR`)
- **a missing direction** — bare `graph`
- **reverse directions** `RL` / `BT`

This parses the declaration with `strings.Fields` instead:

- ignores surrounding/repeated whitespace
- defaults to top-down when no direction is given (matches mermaid's default)
- accepts `TD`/`TB`/`BT`/`LR`/`RL`, mapping the reverse directions onto the axis the renderer lays out (`RL`→LR, `BT`→TD)

## Impact

Tested against a corpus of ~590 real-world mermaid blocks: graph/flowchart rendering went from **147/174 → 173/174** (+26) — every remaining graph failure was this one issue. (The single last failure is an unrelated index-out-of-range panic on one large graph, which I'll report separately.)

## Test plan

- [x] New table-driven test `TestGraphTypeDetection` (whitespace, missing direction, RL/BT, invalid type/direction)
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `gofmt` clean (touched files)