### PR TITLE
feat(sequence): case-insensitive keywords

### DIFF
--- a/cmd/parse_test.go
+++ b/cmd/parse_test.go
@@ -201,6 +201,7 @@ func TestGraphTypeDetection(t *testing.T) {
 		{"CRLF line ending", "graph TD\r\nA --> B", "TD", false},
 		{"tab separator", "graph\tLR\nA --> B", "LR", false},
 		{"lowercase direction errors", "graph td\nA --> B", "", true},
+		{"uppercase graph keyword errors", "GRAPH TD\nA --> B", "", true}, // flowchart stays case-sensitive (mermaid parity)
 		{"extra tokens error", "graph TD foo\nA --> B", "", true},
 		{"unknown type errors", "sequenceDiagram\nA->>B: x", "", true},
 		{"unknown direction errors", "graph SIDEWAYS\nA --> B", "", true},

--- a/pkg/sequence/case_test.go
+++ b/pkg/sequence/case_test.go
@@ -1,0 +1,114 @@
+package sequence
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestSequenceKeywordsCaseInsensitive verifies that every sequence keyword
+// parses in any case. mermaid's sequence grammar declares %options
+// case-insensitive, so upper/mixed-case keywords must behave identically to
+// lowercase. We assert not just that it parses, but that the SEMANTICS are
+// right (the keyword is classified correctly), since the risk is a captured
+// keyword being switched on with the wrong case.
+func TestSequenceKeywordsCaseInsensitive(t *testing.T) {
+	t.Run("diagram keyword", func(t *testing.T) {
+		if _, err := Parse("SEQUENCEDIAGRAM\n A->>B: x"); err != nil {
+			t.Errorf("uppercase sequenceDiagram should parse: %v", err)
+		}
+	})
+
+	t.Run("participant and autonumber", func(t *testing.T) {
+		sd, err := Parse("sequenceDiagram\n PARTICIPANT A as Alice\n AUTONUMBER\n A->>B: x")
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if !sd.Autonumber {
+			t.Error("AUTONUMBER should enable autonumber")
+		}
+		if sd.Participants[0].Label != "Alice" {
+			t.Errorf("participant label = %q, want Alice", sd.Participants[0].Label)
+		}
+	})
+
+	t.Run("loop/end", func(t *testing.T) {
+		mustFragment(t, "sequenceDiagram\n LOOP r\n  A->>B: x\n END", FragmentLoop)
+	})
+	t.Run("opt/end", func(t *testing.T) {
+		mustFragment(t, "sequenceDiagram\n OPT r\n  A->>B: x\n END", FragmentOpt)
+	})
+
+	t.Run("alt/else/end", func(t *testing.T) {
+		sd := mustFragment(t, "sequenceDiagram\n ALT a\n  A->>B: x\n ELSE b\n  A->>B: y\n END", FragmentAlt)
+		if got := altDividers(sd); len(got) != 1 || got[0] != "b" {
+			t.Errorf("ELSE divider = %v, want [b]", got)
+		}
+	})
+
+	t.Run("note placements", func(t *testing.T) {
+		mustNote(t, "sequenceDiagram\n NOTE OVER A: hi", NoteOver)
+		mustNote(t, "sequenceDiagram\n Note Left Of A: hi", NoteLeftOf)
+		mustNote(t, "sequenceDiagram\n note RIGHT OF A: hi", NoteRightOf)
+	})
+
+	t.Run("wrap prefix any case", func(t *testing.T) {
+		n := mustNote(t, "sequenceDiagram\n Note over A:NOWRAP: hello", NoteOver)
+		if n.Text != "hello" {
+			t.Errorf("NOWRAP: prefix should be stripped, got %q", n.Text)
+		}
+	})
+
+	t.Run("lower and upper produce identical structure", func(t *testing.T) {
+		body := "%s\n participant A\n A->>B: x\n %s ok\n  B-->>A: y\n %s no\n  B-->>A: z\n %s"
+		lower := fmt.Sprintf(body, "sequenceDiagram", "alt", "else", "end")
+		upper := fmt.Sprintf(body, "SEQUENCEDIAGRAM", "ALT", "ELSE", "END")
+		lo, err1 := Parse(lower)
+		up, err2 := Parse(upper)
+		if err1 != nil || err2 != nil {
+			t.Fatalf("parse errors: lower=%v upper=%v", err1, err2)
+		}
+		if len(lo.Events) != len(up.Events) || len(lo.Messages) != len(up.Messages) {
+			t.Fatalf("structure differs: lower %d events/%d msgs, upper %d/%d",
+				len(lo.Events), len(lo.Messages), len(up.Events), len(up.Messages))
+		}
+		for i := range lo.Events {
+			if lo.Events[i].Kind != up.Events[i].Kind {
+				t.Errorf("event %d kind differs: %v vs %v", i, lo.Events[i].Kind, up.Events[i].Kind)
+			}
+		}
+	})
+}
+
+func mustFragment(t *testing.T, input string, want FragmentType) *SequenceDiagram {
+	t.Helper()
+	sd, err := Parse(input)
+	if err != nil {
+		t.Fatalf("parse %q: %v", input, err)
+	}
+	for _, ev := range sd.Events {
+		if ev.Kind == EventFragmentStart {
+			if ev.Fragment.Type != want {
+				t.Errorf("fragment type = %v, want %v", ev.Fragment.Type, want)
+			}
+			return sd
+		}
+	}
+	t.Fatalf("no fragment start parsed from %q", input)
+	return nil
+}
+
+func mustNote(t *testing.T, input string, want NotePlacement) *Note {
+	t.Helper()
+	sd, err := Parse(input)
+	if err != nil {
+		t.Fatalf("parse %q: %v", input, err)
+	}
+	n := firstNote(sd)
+	if n == nil {
+		t.Fatalf("no note parsed from %q", input)
+	}
+	if n.Placement != want {
+		t.Errorf("placement = %v, want %v", n.Placement, want)
+	}
+	return n
+}

--- a/pkg/sequence/parser.go
+++ b/pkg/sequence/parser.go
@@ -16,7 +16,7 @@ const (
 
 var (
 	// participantRegex matches participant declarations: participant [ID] [as Label]
-	participantRegex = regexp.MustCompile(`^\s*participant\s+(?:"([^"]+)"|(\S+))(?:\s+as\s+(.+))?$`)
+	participantRegex = regexp.MustCompile(`(?i)^\s*participant\s+(?:"([^"]+)"|(\S+))(?:\s+as\s+(.+))?$`)
 
 	// messageRegex matches messages: [From][arrow][To]: [Label]. The arrow is one
 	// of ->>, -->>, -> or -->. Unquoted participant names exclude the arrow
@@ -26,24 +26,24 @@ var (
 	messageRegex = regexp.MustCompile(`^\s*(?:"([^"]+)"|([^\s<>-]+))\s*(-->>|-->|->>|->)\s*(?:"([^"]+)"|([^\s<>-]+))\s*:\s*(.*)$`)
 
 	// autonumberRegex matches the autonumber directive
-	autonumberRegex = regexp.MustCompile(`^\s*autonumber\s*$`)
+	autonumberRegex = regexp.MustCompile(`(?i)^\s*autonumber\s*$`)
 
 	// fragmentStartRegex matches the opening line of a control-flow fragment,
 	// e.g. "loop every minute", "opt is premium", "alt is valid". Group 1 is the
 	// keyword, group 2 is the (optional) label describing the condition.
-	fragmentStartRegex = regexp.MustCompile(`^\s*(loop|opt|alt)\b\s*(.*)$`)
+	fragmentStartRegex = regexp.MustCompile(`(?i)^\s*(loop|opt|alt)\b\s*(.*)$`)
 
 	// fragmentElseRegex matches an "else" divider inside an alt block. Group 1 is
 	// the (optional) condition label for the following section.
-	fragmentElseRegex = regexp.MustCompile(`^\s*else\b\s*(.*)$`)
+	fragmentElseRegex = regexp.MustCompile(`(?i)^\s*else\b\s*(.*)$`)
 
 	// fragmentEndRegex matches the "end" line that closes a fragment.
-	fragmentEndRegex = regexp.MustCompile(`^\s*end\s*$`)
+	fragmentEndRegex = regexp.MustCompile(`(?i)^\s*end\s*$`)
 
 	// noteRegex matches note annotations: "Note over A: text", "note left of A:
 	// text", "Note over A,B: text" (case-insensitive keyword). Group 1 is the
 	// placement, group 2 the participant list, group 3 the text.
-	noteRegex = regexp.MustCompile(`^\s*[Nn]ote\s+(right of|left of|over)\s+([^:]+?)\s*:\s*(.*)$`)
+	noteRegex = regexp.MustCompile(`(?i)^\s*note\s+(right of|left of|over)\s+([^:]+?)\s*:\s*(.*)$`)
 )
 
 // SequenceDiagram represents a parsed sequence diagram.
@@ -202,9 +202,23 @@ func IsSequenceDiagram(input string) bool {
 		if trimmed == "" || strings.HasPrefix(trimmed, "%%") {
 			continue
 		}
-		return strings.HasPrefix(trimmed, SequenceDiagramKeyword)
+		return hasSequenceKeyword(trimmed)
 	}
 	return false
+}
+
+// hasSequenceKeyword reports whether a line is the sequenceDiagram declaration,
+// case-insensitively (mermaid's sequence grammar is case-insensitive). The
+// keyword must stand as a whole token — followed by whitespace or end of line —
+// so a node id like "sequenceDiagramFoo" in a flowchart isn't misrouted here.
+func hasSequenceKeyword(line string) bool {
+	lower := strings.ToLower(strings.TrimSpace(line))
+	kw := strings.ToLower(SequenceDiagramKeyword)
+	if !strings.HasPrefix(lower, kw) {
+		return false
+	}
+	rest := lower[len(kw):]
+	return rest == "" || rest[0] == ' ' || rest[0] == '\t'
 }
 
 func Parse(input string) (*SequenceDiagram, error) {
@@ -219,7 +233,7 @@ func Parse(input string) (*SequenceDiagram, error) {
 		return nil, fmt.Errorf("no content found")
 	}
 
-	if !strings.HasPrefix(strings.TrimSpace(lines[0]), SequenceDiagramKeyword) {
+	if !hasSequenceKeyword(strings.TrimSpace(lines[0])) {
 		return nil, fmt.Errorf("expected %q keyword", SequenceDiagramKeyword)
 	}
 	lines = lines[1:]
@@ -252,7 +266,7 @@ func Parse(input string) (*SequenceDiagram, error) {
 		// "Note->>B: hi") still parses as a message further down.
 		if m := noteRegex.FindStringSubmatch(trimmed); m != nil {
 			placement := NoteOver
-			switch m[1] {
+			switch strings.ToLower(m[1]) { // keyword may be any case
 			case "left of":
 				placement = NoteLeftOf
 			case "right of":
@@ -272,7 +286,7 @@ func Parse(input string) (*SequenceDiagram, error) {
 			// wrapping is irrelevant for single-line ASCII, so just strip it.
 			text := strings.TrimSpace(m[3])
 			for _, pre := range []string{"nowrap:", "wrap:"} {
-				if strings.HasPrefix(text, pre) {
+				if strings.HasPrefix(strings.ToLower(text), pre) {
 					text = strings.TrimSpace(text[len(pre):])
 					break
 				}
@@ -301,7 +315,7 @@ func Parse(input string) (*SequenceDiagram, error) {
 
 		// A fragment opener ("loop"/"opt"/"alt") starts a framed block.
 		if match := fragmentStartRegex.FindStringSubmatch(trimmed); match != nil {
-			fType := map[string]FragmentType{"loop": FragmentLoop, "opt": FragmentOpt, "alt": FragmentAlt}[match[1]]
+			fType := map[string]FragmentType{"loop": FragmentLoop, "opt": FragmentOpt, "alt": FragmentAlt}[strings.ToLower(match[1])]
 			sd.Events = append(sd.Events, Event{
 				Kind:     EventFragmentStart,
 				Fragment: &Fragment{Type: fType, Label: strings.TrimSpace(match[2])},

--- a/pkg/sequence/sequence_test.go
+++ b/pkg/sequence/sequence_test.go
@@ -57,6 +57,9 @@ func TestIsSequenceDiagram(t *testing.T) {
 		want  bool
 	}{
 		{"sequenceDiagram\nA->>B: Hello", true},
+		{"SEQUENCEDIAGRAM\nA->>B: Hello", true}, // case-insensitive dispatch
+		{"SequenceDiagram\nA->>B: Hello", true}, // mixed case
+		{"sequenceDiagramFoo-->B", false},       // token boundary: a node id, not the keyword
 		{"graph LR\nA-->B", false},
 		{"graph TD\nA-->B", false},
 		{"", false},


### PR DESCRIPTION
## Summary

mermaid's sequence grammar is declared `%options case-insensitive`, but our sequence keyword matchers were lowercase-only — except `note`, which was `[Nn]ote` (an inconsistency). This makes **all sequence keywords case-insensitive** to match mermaid: `sequenceDiagram`, `participant`/`as`, `autonumber`, `loop`/`opt`/`alt`/`else`/`end`, `note`/`over`/`left of`/`right of`, and the `wrap:`/`nowrap:` prefix.

- `(?i)` on the sequence keyword regexes
- captured keywords are lower-cased before being switched on (note placement, fragment type, wrap prefix) — so **classification** is case-insensitive while participant IDs, labels, and note/message **text keep their original case**
- `sequenceDiagram` detection is case-insensitive and now token-bounded (a flowchart node id like `sequenceDiagramFoo` is not misrouted)

**Flowchart/graph keywords and directions are intentionally left case-sensitive** — mermaid's flowchart grammar is *not* `%options case-insensitive` (it rejects `GRAPH TD` and lowercase directions), and treating flowchart `end` case-insensitively would misparse a node literally named `End`. A test locks this.

Part of #74.

## Test plan

- [x] Every sequence keyword in upper/mixed case parses **and classifies correctly** (fragment type, note placement, autonumber flag) — not just no-error
- [x] Upper vs lower full-diagram structural equivalence
- [x] Case-insensitive dispatch (`IsSequenceDiagram`) incl. the `sequenceDiagramFoo` token-boundary case
- [x] Lock: flowchart stays case-sensitive (`GRAPH TD` errors)
- [x] `go test ./...`, `go vet`, `gofmt` clean; existing lowercase output byte-identical