### PR TITLE
fix(graph): grow level tracking to avoid panic on long chains

### DIFF
--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -181,13 +181,10 @@ func (g *graph) setSubgraphs(textSubgraphs []*textSubgraph) {
 }
 
 func (g *graph) createMapping() {
-	// Set mapping coord for every node in the graph
-	highestPositionPerLevel := []int{}
-	// Init array with 0 values
-	// TODO: I'm sure there's a better way of doing this
-	for i := 0; i < 100; i++ {
-		highestPositionPerLevel = append(highestPositionPerLevel, 0)
-	}
+	// Set mapping coord for every node in the graph.
+	// Keyed by level so it grows with the graph instead of assuming a fixed
+	// number of levels; a missing key reads as the zero value.
+	highestPositionPerLevel := map[int]int{}
 
 	// TODO: should the mapping be bottom-to-top instead of top-to-bottom?
 	// Set root nodes to level 0

--- a/cmd/render_graph_test.go
+++ b/cmd/render_graph_test.go
@@ -1,12 +1,32 @@
 package cmd
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/AlexanderGrooff/mermaid-ascii/pkg/diagram"
 	"github.com/mattn/go-runewidth"
 )
+
+func TestRenderGraphHandlesLongChainWithoutPanic(t *testing.T) {
+	config := diagram.NewTestConfig(true, "cli")
+
+	var b strings.Builder
+	b.WriteString("graph TD\n")
+	for i := 1; i < 30; i++ {
+		fmt.Fprintf(&b, "N%d --> N%d\n", i, i+1)
+	}
+
+	output, err := RenderDiagram(b.String(), config)
+	if err != nil {
+		t.Fatalf("RenderDiagram() error = %v", err)
+	}
+
+	if !strings.Contains(output, "N30") {
+		t.Fatalf("expected output to contain the last node\noutput:\n%s", output)
+	}
+}
 
 func TestRenderGraphKeepsDisplayWidthForWideNodeLabels(t *testing.T) {
 	config := diagram.NewTestConfig(true, "cli")


### PR DESCRIPTION
Fixes #80.

`createMapping` pre-filled `highestPositionPerLevel` with exactly 100 entries and then indexed it by level. Each node in a `graph TD` chain advances the level by 4, so a chain of 25 nodes reaches index 100 and panics with `index out of range [100] with length 100`.

Switched the tracker to a map keyed by level so it grows with the graph, and reads of a missing level still return 0 as before. Added a regression test that renders a long chain and passes only with the fix.